### PR TITLE
Parser and Storage: Add defensive assertions

### DIFF
--- a/src/main/java/sky/Parser.java
+++ b/src/main/java/sky/Parser.java
@@ -15,6 +15,8 @@ public class Parser {
      * @return Corresponding command type
      */
     public static CommandType parseCommandType(String input) {
+        assert input != null : "Parser.parseCommandType: input should not be null";
+
         String trimmed = input.trim();
 
         if (trimmed.startsWith("todo")) {
@@ -57,6 +59,11 @@ public class Parser {
      * @throws SkyException If the index is invalid
      */
     public static int parseIndex(String input, String command) throws SkyException {
+        assert input != null : "Parser.parseIndex: input should not be null";
+        assert command != null : "Parser.parseIndex: command should not be null";
+        assert input.startsWith(command)
+                : "Parser.parseIndex: input must start with command";
+
         try {
             int index = Integer.parseInt(
                     input.substring(command.length()).trim()
@@ -80,6 +87,9 @@ public class Parser {
      * @throws SkyException If the date format is invalid
      */
     public static LocalDate parseDate(String value, String fieldName) throws SkyException {
+        assert value != null : "Parser.parseDate: value should not be null";
+    assert fieldName != null : "Parser.parseDate: fieldName should not be null";
+
         try {
             return LocalDate.parse(value.trim());
         } catch (DateTimeParseException e) {

--- a/src/main/java/sky/Storage.java
+++ b/src/main/java/sky/Storage.java
@@ -87,8 +87,13 @@ public class Storage {
      * @throws IllegalArgumentException If the task type is invalid
      */
     private static Task parseTask(String line) {
+        assert line != null : "Storage.parseTask: line should not be null";
+
         String[] parts = line.split(" \\| ");
         boolean isDone = parts[1].equals("1");
+
+        assert parts.length >= 3
+            : "Storage.parseTask: invalid file format";
 
         Task task;
         switch (parts[0]) {
@@ -96,9 +101,13 @@ public class Storage {
                 task = new Todo(parts[2]);
                 break;
             case "D":
+                assert parts.length == 4
+                    : "Deadline format should have 4 fields";
                 task = new Deadline(parts[2], LocalDate.parse(parts[3]));
                 break;
             case "E":
+                assert parts.length == 5
+                    : "Event format should have 5 fields";
                 task = new Event(parts[2], LocalDate.parse(parts[3]), LocalDate.parse(parts[4]));
                 break;
             default:


### PR DESCRIPTION
Parser and Storage assume certain preconditions about input values and file formats. These assumptions are implicit and not documented in the code.

If these assumptions are violated, the program may fail in ways that are difficult to debug.

Add assertions to document important internal assumptions such as:
* input parameters should not be null
* parseIndex input should start with the command keyword
* storage file lines should follow the expected field format

Assertions are used only for developer-level contract validation, not for handling user input errors.

This makes invariants explicit and helps detect logic errors early during development.